### PR TITLE
Step12 : DB Lock 별 낙관적 Lock 동시성 코드 작성

### DIFF
--- a/hhplus0011/src/main/java/com/tdd/ecommerce/cart/domain/CartRepository.java
+++ b/hhplus0011/src/main/java/com/tdd/ecommerce/cart/domain/CartRepository.java
@@ -13,4 +13,8 @@ public interface CartRepository {
     void deleteByCustomerId(Long customerId);
 
     void deleteCartByCustomerIdAndProductId(Long customerId, Long productId);
+
+    void getLock(String key);
+
+    void releaseLock(String key);
 }

--- a/hhplus0011/src/main/java/com/tdd/ecommerce/cart/infrastructure/CartJpaRepository.java
+++ b/hhplus0011/src/main/java/com/tdd/ecommerce/cart/infrastructure/CartJpaRepository.java
@@ -22,4 +22,10 @@ public interface CartJpaRepository extends JpaRepository<Cart, Long> {
     @Modifying
     @Query("DELETE FROM Cart c WHERE c.customerId = :customerId AND c.product.productId = :productId")
     void deleteCartByCustomerIdAndProductId(Long customerId, Long productId);
+
+    @Query(value = "select get_lock(:key, 100)", nativeQuery = true)
+    void getLock(String key);
+
+    @Query(value = "select release_lock(:key)", nativeQuery = true)
+    void releaseLock(String key);
 }

--- a/hhplus0011/src/main/java/com/tdd/ecommerce/cart/infrastructure/CartRepositoryImpl.java
+++ b/hhplus0011/src/main/java/com/tdd/ecommerce/cart/infrastructure/CartRepositoryImpl.java
@@ -34,4 +34,14 @@ public class CartRepositoryImpl implements CartRepository {
     public void deleteCartByCustomerIdAndProductId(Long customerId, Long productId){
         cartJpaRepository.deleteCartByCustomerIdAndProductId(customerId, productId);
     }
+
+    @Override
+    public void getLock(String key){
+        cartJpaRepository.getLock(key);
+    }
+
+    @Override
+    public void releaseLock(String key){
+        cartJpaRepository.releaseLock(key);
+    }
 }

--- a/hhplus0011/src/main/java/com/tdd/ecommerce/customer/domain/Customer.java
+++ b/hhplus0011/src/main/java/com/tdd/ecommerce/customer/domain/Customer.java
@@ -25,6 +25,10 @@ public class Customer extends TimeStamped {
     @Column(name="balance")
     private Long balance;
 
+    @Version
+    @Column(name="version")
+    private Long version;
+
     public Long chargeBalance(Long amount) {
         if(amount < 0)
             throw new BusinessException(ECommerceExceptions.INVALID_AMOUNT);

--- a/hhplus0011/src/main/java/com/tdd/ecommerce/customer/domain/CustomerRepository.java
+++ b/hhplus0011/src/main/java/com/tdd/ecommerce/customer/domain/CustomerRepository.java
@@ -6,4 +6,5 @@ public interface CustomerRepository{
 
     Optional<Customer> findById(Long customerId);
     Customer save(Customer customer);
+    Optional<Customer> findByIdWithOptimisticLock(Long customerId);
 }

--- a/hhplus0011/src/main/java/com/tdd/ecommerce/customer/infrastructure/CustomerJpaRepository.java
+++ b/hhplus0011/src/main/java/com/tdd/ecommerce/customer/infrastructure/CustomerJpaRepository.java
@@ -1,7 +1,16 @@
 package com.tdd.ecommerce.customer.infrastructure;
 
 import com.tdd.ecommerce.customer.domain.Customer;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
 
 public interface CustomerJpaRepository extends JpaRepository<Customer, Long> {
+
+    @Lock(LockModeType.OPTIMISTIC)
+    @Query("SELECT c FROM Customer c WHERE c.customerId = :customerId")
+    Optional<Customer> findByIdWithOptimisticLock(Long customerId);
 }

--- a/hhplus0011/src/main/java/com/tdd/ecommerce/customer/infrastructure/CustomerRepositoryImpl.java
+++ b/hhplus0011/src/main/java/com/tdd/ecommerce/customer/infrastructure/CustomerRepositoryImpl.java
@@ -23,4 +23,9 @@ public class CustomerRepositoryImpl  implements CustomerRepository {
     public Customer save(Customer customer) {
         return customerJpaRepository.save(customer);
     }
+
+    @Override
+    public Optional<Customer> findByIdWithOptimisticLock(Long customerId) {
+        return customerJpaRepository.findByIdWithOptimisticLock(customerId);
+    }
 }

--- a/hhplus0011/src/main/java/com/tdd/ecommerce/customer/presentation/CustomerController.java
+++ b/hhplus0011/src/main/java/com/tdd/ecommerce/customer/presentation/CustomerController.java
@@ -58,4 +58,17 @@ public class CustomerController {
           return ResponseUtil.buildErrorResponse(ECommerceExceptions.INVALID_CUSTOMER, ECommerceExceptions.INVALID_CUSTOMER.getMessage());
       }
   }
+
+    @PatchMapping("/{customer_id}/balance/charge2")
+    public ResponseEntity<?> chargeBalanceWithOptimisticLock(@PathVariable("customer_id") Long customerId, @RequestBody CustomerRequest request) {
+        try {
+            request.validate();
+
+            CustomerServiceResponse customerServiceResponse = customerService.chargeCustomerBalanceWithOptimisticLocking(customerId, request.balance());
+            return ResponseUtil.buildSuccessResponse(request.balance() + " point 충전이 완료되었습니다..", customerServiceResponse);
+
+        } catch (IllegalArgumentException e) {
+            return ResponseUtil.buildErrorResponse(CommonExceptions.INVALID_PARAMETER, CommonExceptions.INVALID_PARAMETER.getMessage());
+        }
+    }
 }

--- a/hhplus0011/src/main/java/com/tdd/ecommerce/product/domain/ProductInfoDto.java
+++ b/hhplus0011/src/main/java/com/tdd/ecommerce/product/domain/ProductInfoDto.java
@@ -2,6 +2,7 @@ package com.tdd.ecommerce.product.domain;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import org.springframework.data.annotation.Id;
 
 @Data
 @AllArgsConstructor

--- a/hhplus0011/src/test/java/com/tdd/ecommerce/cart/CartIntegrationTest.java
+++ b/hhplus0011/src/test/java/com/tdd/ecommerce/cart/CartIntegrationTest.java
@@ -149,7 +149,7 @@ public class CartIntegrationTest {
     }
 
     private Long createNewCustomerAndGetId(){
-        Customer customer = new Customer(null, 10000L);
+        Customer customer = new Customer(null, 10000L, 0L);
 
         return customerRepository.save(customer).getCustomerId();
     }

--- a/hhplus0011/src/test/java/com/tdd/ecommerce/customer/presentation/CustomerConcurrencyTest.java
+++ b/hhplus0011/src/test/java/com/tdd/ecommerce/customer/presentation/CustomerConcurrencyTest.java
@@ -1,0 +1,73 @@
+package com.tdd.ecommerce.customer.presentation;
+
+import com.tdd.ecommerce.customer.application.CustomerService;
+import com.tdd.ecommerce.customer.domain.Customer;
+import com.tdd.ecommerce.customer.domain.CustomerRepository;
+import jakarta.persistence.OptimisticLockException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
+import org.springframework.test.context.jdbc.Sql;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@SpringBootTest()
+@Sql(scripts = "/reset-database.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+public class CustomerConcurrencyTest {
+
+    @Autowired
+    CustomerService sut;
+
+    @Autowired
+    CustomerRepository customerRepository;
+
+    @Test
+    @DisplayName("한 고객에게 복수의 포인트 충전 요청을 보내면 한번만 성공한다.")
+    void chargeMultiPoint() throws InterruptedException {
+
+        int requestNum = 2;
+        Long chargeAmount = 2000L;
+
+        Long customerId = customerRepository.save(new Customer(null, 1000L, 0L)).getCustomerId();
+
+        AtomicInteger successCount = new AtomicInteger(0);
+        AtomicInteger failureCount = new AtomicInteger(0);
+
+        CountDownLatch latch = new CountDownLatch(requestNum);
+
+        ExecutorService executorService = Executors.newFixedThreadPool(requestNum);
+
+        for(int i = 0; i < requestNum; i++){
+            executorService.submit(()->{
+               try{
+                   sut.chargeCustomerBalanceWithOptimisticLocking(customerId, chargeAmount);
+
+                   successCount.incrementAndGet();
+               }catch(OptimisticLockException | ObjectOptimisticLockingFailureException e){
+                   failureCount.incrementAndGet();
+               }finally {
+                   latch.countDown();
+               }
+            });
+        }
+        latch.await();
+        executorService.shutdown();
+
+        // 잔액 및 성공, 실패 카운트 확인
+        Long finalBalance = sut.getCustomerBalance(customerId).getBalance();
+        System.out.println("최종 잔액: " + finalBalance);
+        System.out.println("성공 횟수: " + successCount.get());
+        System.out.println("실패 횟수: " + failureCount.get());
+
+        // Thread의 DB Connection은 최대 10개이므로, 10개이상 동시에 요청을 했을 때에는 1개 이상의 요청이 성공할 수 있다.
+        assertEquals(1, successCount.get());
+        assertEquals(chargeAmount * successCount.get() + 1000L , finalBalance); // 초기 잔액 1000L
+    }
+}

--- a/hhplus0011/src/test/java/com/tdd/ecommerce/customer/presentation/CustomerIntegrationTest.java
+++ b/hhplus0011/src/test/java/com/tdd/ecommerce/customer/presentation/CustomerIntegrationTest.java
@@ -30,7 +30,7 @@ public class CustomerIntegrationTest {
     @DisplayName("🟢고객 한명의 포인트를 조회하면 1000이 반환된다.")
     void getCustomerBalance_SUCCESS() {
         //given
-        Long customerId = customerRepository.save(new Customer(null, 1000L)).getCustomerId();
+        Long customerId = customerRepository.save(new Customer(null, 1000L, 0L)).getCustomerId();
         //when
         CustomerServiceResponse result = sut.getCustomerBalance(customerId);
 
@@ -59,7 +59,7 @@ public class CustomerIntegrationTest {
     @DisplayName("🟢고객 포인트 충전을 성공하면 합산된 포인트 11000이 반환된다. ")
     void chargeBalance_SUCCESS(){
         //given
-        Long customerId = customerRepository.save(new Customer(null, 1000L)).getCustomerId();
+        Long customerId = customerRepository.save(new Customer(null, 1000L, 0L)).getCustomerId();
         Long chargeAmount = 10000L;
 
         CustomerServiceResponse result = sut.chargeCustomerBalance(customerId, chargeAmount);

--- a/hhplus0011/src/test/java/com/tdd/ecommerce/customer/presentation/CustomerServiceTest.java
+++ b/hhplus0011/src/test/java/com/tdd/ecommerce/customer/presentation/CustomerServiceTest.java
@@ -30,7 +30,7 @@ class CustomerServiceTest {
     @DisplayName("🟢유효한 고객의 잔액을 조회하면 10000이 반환된다.")
     void getBalance_SUCCESS() {
         //given
-        Customer customer = new Customer(1L, 10000L);
+        Customer customer = new Customer(1L, 10000L,0L);
 
         when(customerRepository.findById(1L)).thenReturn(Optional.of(customer));
 
@@ -57,7 +57,7 @@ class CustomerServiceTest {
     @Test
     @DisplayName("🟢유효한 고객의 잔액을 충전하면 충전금액 10000이 반환된다.")
     void chargeBalance_SUCCESS() {
-        Customer customer = new Customer( 1L, 10000L);
+        Customer customer = new Customer( 1L, 10000L, 0L);
         Long chargeAmount = 500L;
         when(customerRepository.findById(1L)).thenReturn(Optional.of(customer));
 
@@ -70,7 +70,7 @@ class CustomerServiceTest {
     @Test
     @DisplayName("🔴 유효하지 않은 고객의 충전을 시도했을 시 BusinessException이 발생한다.")
     void chargeBalance_INVALIDCUSTOMER() {
-        Customer customer = new Customer(1L, 10000L);
+        Customer customer = new Customer(1L, 10000L, 0L);
         Long chargeAmount = 500L;
 
         when(customerRepository.findById(1L)).thenReturn(Optional.empty());

--- a/hhplus0011/src/test/java/com/tdd/ecommerce/order/application/OrderIntegrationTest.java
+++ b/hhplus0011/src/test/java/com/tdd/ecommerce/order/application/OrderIntegrationTest.java
@@ -51,7 +51,7 @@ public class OrderIntegrationTest {
     @BeforeEach
     public void setUp() {
 
-        Customer customer = new Customer(null, 100000L);
+        Customer customer = new Customer(null, 100000L, 0L);
         customerId = customerRepository.save(customer).getCustomerId();
 
         Product product = new Product(null, "Test Product", 10000L,"etc", null);

--- a/hhplus0011/src/test/java/com/tdd/ecommerce/order/application/OrderServiceTest.java
+++ b/hhplus0011/src/test/java/com/tdd/ecommerce/order/application/OrderServiceTest.java
@@ -130,7 +130,7 @@ class OrderServiceTest {
 
         List<OrderProduct> orderProducts = List.of(new OrderProduct(null, 1L, 1L, 2L, 30000L));
 
-        Customer customer = new Customer(customerId, 5000000L);
+        Customer customer = new Customer(customerId, 5000000L, 0L);
         ProductInventory inventory = new ProductInventory(1L, 1L, 10L);
 
         when(customerRepository.findById(customerId)).thenReturn(Optional.of(customer));
@@ -172,7 +172,7 @@ class OrderServiceTest {
         Long customerId = 1L;
         List<OrderProduct> orderProducts = List.of(new OrderProduct(null, 1L, 1L, 2L, 10000L));
 
-        Customer customer = new Customer(null, 10000L);  // 잔액 부족
+        Customer customer = new Customer(null, 10000L, 0L);  // 잔액 부족
         Product product = new Product(1L, "Test Product", 10000L, "etc", null);
         ProductInventory inventory = new ProductInventory(1L, 10L,5L);
 


### PR DESCRIPTION
# 금주 주제 
* 다양한 DB Lock을 이용해서 동시성 이슈 제어해보기. 


# 1. 🔐 포인트 충전 시 발생할 수 있는 동시성 문제. 
* "따닥이슈"로 동시에 한명의 고객에게 같은 충전 요청이 들어올 수 있고 가정했습니다. 
* 첫 요청 제외하고는 다 반영하지 않으면 됩니다.
* 재시도 로직이 없기에 코드 구현복잡도가 낮아질거라 생각했습니다.
* 한번 거절 당한 요청을 다시 요청하고 싶을 때에는 프론트에서 버튼 활.비활성화를 통해 요청할 수 있습니다. 

그래서 **낙관적 락**으로 구현하였습니다.
<a href='hhplus0011/src/test/java/com/tdd/ecommerce/customer/presentation/CustomerConcurrencyTest.java'>낙관적 락 테스트</a>

# 2. 🔐상품 구매시 재고차감하는 동시성 문제
* 이벤트로 하나의 상품에 구매자가 몰리게되면 재고관리는 최신으로 관리되어야한다. 
* 충돌이 잦고 정합성이 중요한 테이블 이므로 

**비관적 락**으로 구현했습니다. 
<a href='https://github.com/devNana222/ohsir39cm/blob/main/hhplus0011/src/test/java/com/tdd/ecommerce/order/application/OrderConcurrencyTest.java'>비관적 락 테스트</a>

# 3. 아쉬웠던 점 
* MySQL을 사용하는 김에 Named Lock을 사용하려 했습니다. 
* 카트를 <a href='https://github.com/devNana222/ohsir39cm/pull/22/files#diff-8a994755bdd810e8495946f572402a92db9a8b38664977beeaf1e1eaa88f78c9a'>NamedLock으로 구현</a>했는데 최신의 카트 정보를 불러오지 못해 테스트가 계속 실패했습니다. 
* 굳이 적용하지 않아도 되는 부분같아 pr에서는 제외하였지만 코드 실패 원인을 한번 봐주시면 감사하겠습니다! 
